### PR TITLE
Feat/#3/공통 모바일뷰 세팅

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -42,3 +42,8 @@
 body {
   font-family: 'Pretendard-Regular'; /*기본 폰트 설정*/
 }
+
+.full-height {
+  /* 모바일 뷰포트 높이 설정 */
+  height: calc(var(--vh, 1vh) * 100);
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,9 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import { RouterProvider } from 'react-router-dom'
 import router from './router'
+import setViewport from './styles/setViewport'
+
+setViewport()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/styles/setViewport.js
+++ b/src/styles/setViewport.js
@@ -1,0 +1,6 @@
+function setViewportHeight() {
+  const vh = window.innerHeight * 0.01
+  document.documentElement.style.setProperty('--vh', `${vh}px`)
+}
+
+export default setViewportHeight


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. -->
  closed #5 

## ✨ Work Description
<!-- 구현한 부분에 대해 설명해주세요. -->
- `styles` 폴더 내 `setViewport.js` 파일에 setViewportHeight 함수 작성
- `main.jsx`에서 import 및 함수 호출 완료
- `index.css (최상위 css 파일)`에 클래스 추가

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
### 사용법
- 페이지의 루트 요소에 클래스 붙여서 사용해주세요!
(ex)
```pages/IntroPage.jsx
function IntroPage() {
  return (
    <section className="full-height">
      <h1>어서와!</h1>
      <p>이건 한 화면을 꽉 채우는 인트로 페이지야.</p>
    </section>
  );
}

export default IntroPage;
```
```pages/LoginPage.jsx
function LoginPage() {
  return (
    <div className="full-height flex items-center justify-center">
      <form className="login-box">
        <h2>로그인</h2>
        <input placeholder="이메일" />
        <input placeholder="비밀번호" />
        <button>로그인</button>
      </form>
    </div>
  );
}
```

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->

## 🛜 참고 문서
- footer 적용의 경우도 나와있어요!
https://woody-j.tistory.com/163
- 노션에 있던 문서!
https://s0ojin.tistory.com/56